### PR TITLE
JSchemaGenerator: support multiple generators in the collection

### DIFF
--- a/Src/Newtonsoft.Json.Schema.Tests/JSchemaGeneratorTests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/JSchemaGeneratorTests.cs
@@ -278,6 +278,52 @@ namespace Newtonsoft.Json.Schema.Tests
             Assert.AreEqual("OrdinalIgnoreCase", (string)propertySchema.Enum[5]);
         }
 
+        [Test]
+        public void When_using_multiple_generation_providers()
+        {
+            var generator = new JSchemaGenerator();
+            generator.GenerationProviders.Add(new StringEnumGenerationProvider());
+            generator.GenerationProviders.Add(new DateTimeGenerationProvider());
+
+            var schema = generator.Generate(typeof(TestMutliGenerationProviderClass));
+
+            var dateProp = schema.Properties["DateOfBirth"];
+            Assert.AreEqual("date-time", dateProp.Format);
+
+            var enumProp = schema.Properties["Role"];
+            Assert.AreEqual("Restricted", (string)enumProp.Enum[0]);
+            Assert.AreEqual("Normal", (string)enumProp.Enum[1]);
+            Assert.AreEqual("Super", (string)enumProp.Enum[2]);
+        }
+
+        public class DateTimeGenerationProvider : JSchemaGenerationProvider
+        {
+            public override JSchema GetSchema(JSchemaTypeGenerationContext context)
+            {
+                if (context.ObjectType != typeof(DateTime))
+                    return null;
+
+                var generator = new JSchemaGenerator();
+                var schema = generator.Generate(context.ObjectType);
+                schema.Format = "date-time";
+
+                return schema;
+            }
+        }
+
+        public class TestMutliGenerationProviderClass
+        {
+            public Roles Role { get; set; }
+            public DateTime DateOfBirth { get; set; }
+        }
+
+        public enum Roles
+        {
+            Restricted,
+            Normal,
+            Super
+        }
+
 #if !(NET40 || NET35)
         public class DictionaryWithMinAndMaxLength
         {

--- a/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
@@ -217,7 +217,12 @@ namespace Newtonsoft.Json.Schema.Generation
 
                 foreach (JSchemaGenerationProvider generationProvider in _generator._generationProviders)
                 {
-                    schema = generationProvider.GetSchema(context);
+                    var generated = generationProvider.GetSchema(context);
+
+                    if (generated != null)
+                    {
+                        schema = generated;
+                    }
                 }
             }
 


### PR DESCRIPTION
Currently when adding multiple `GenerationProviders` to  the `JSchemaGenerator.GenerationProviders` collection it only will use the result of the last added generator, even if it returns null.

I was unsure whether to fix this by doing as I have (last non null schema is used), or using something similar to:
```c#
schema = _generator._generationProviders
    .Select(g => g.GetSchema(context))
    .FirstOrDefault(s => s != null);
```