### PR TITLE
Use internal schema generator when converter cannot write

### DIFF
--- a/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
@@ -316,7 +316,7 @@ namespace Newtonsoft.Json.Schema.Generation
             schema.Title = GetTitle(contract.NonNullableUnderlyingType);
             schema.Description = GetDescription(contract.NonNullableUnderlyingType);
 
-            JsonConverter converter = contract.Converter ?? contract.InternalConverter;
+            JsonConverter converter = (contract.Converter != null && contract.Converter.CanWrite) ? contract.Converter : contract.InternalConverter;
 
             if (converter != null)
             {


### PR DESCRIPTION
This fixes my issue where a JsonConverter attribute is used on a type, which then requires  a SchemaGenerationProvider, even though the JsonConverter can not write json.
All tests passed.