### PR TITLE
Use null-propogation where applicable and useful.

### DIFF
--- a/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
@@ -112,7 +112,7 @@ namespace Newtonsoft.Json.Schema.Generation
         {
             JsonContainerAttribute containerAttribute = JsonTypeReflector.GetCachedAttribute<JsonContainerAttribute>(type);
 
-            if (containerAttribute != null && !string.IsNullOrEmpty(containerAttribute.Title))
+            if (!string.IsNullOrEmpty(containerAttribute?.Title))
             {
                 return containerAttribute.Title;
             }
@@ -124,20 +124,17 @@ namespace Newtonsoft.Json.Schema.Generation
         {
             JsonContainerAttribute containerAttribute = JsonTypeReflector.GetCachedAttribute<JsonContainerAttribute>(type);
 
-            if (containerAttribute != null && !string.IsNullOrEmpty(containerAttribute.Description))
+            if (!string.IsNullOrEmpty(containerAttribute?.Description))
             {
                 return containerAttribute.Description;
             }
 
 #if !(NETFX_CORE || PORTABLE40 || PORTABLE)
             DescriptionAttribute descriptionAttribute = ReflectionUtils.GetAttribute<DescriptionAttribute>(type);
-            if (descriptionAttribute != null)
-            {
-                return descriptionAttribute.Description;
-            }
-#endif
-
+            return descriptionAttribute?.Description;
+#else
             return null;
+#endif
         }
 
         private Uri GetTypeId(Type type, bool explicitOnly)
@@ -146,7 +143,7 @@ namespace Newtonsoft.Json.Schema.Generation
 
             Uri typeId;
 
-            if (containerAttribute != null && !string.IsNullOrEmpty(containerAttribute.Id))
+            if (!string.IsNullOrEmpty(containerAttribute?.Id))
             {
                 typeId = new Uri(containerAttribute.Id, UriKind.RelativeOrAbsolute);
             }
@@ -189,7 +186,7 @@ namespace Newtonsoft.Json.Schema.Generation
         {
             JSchemaGenerationProviderAttribute providerAttribute = null;
 
-            if (memberProperty != null && memberProperty.AttributeProvider != null)
+            if (memberProperty?.AttributeProvider != null)
             {
                 providerAttribute = (JSchemaGenerationProviderAttribute)memberProperty.AttributeProvider.GetAttributes(typeof(JSchemaGenerationProviderAttribute), true).SingleOrDefault();
             }

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/JSchemaReader.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/JSchemaReader.cs
@@ -163,7 +163,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure
         {
             JTokenPathAnnotation pathAnnotation = inlineToken.Root.Annotation<JTokenPathAnnotation>();
             string path;
-            if (pathAnnotation != null && !string.IsNullOrEmpty(pathAnnotation.BasePath))
+            if (!string.IsNullOrEmpty(pathAnnotation?.BasePath))
             {
                 path = pathAnnotation.BasePath;
 

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/Validation/Validator.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/Validation/Validator.cs
@@ -132,10 +132,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure.Validation
                 SchemaScope.CreateTokenScope(token, Schema, _context, null, depth);
             }
 
-            if (TokenWriter != null)
-            {
-                TokenWriter.WriteToken(token, value);
-            }
+            TokenWriter?.WriteToken(token, value);
 
             for (int i = _scopes.Count - 1; i >= 0; i--)
             {

--- a/Src/Newtonsoft.Json.Schema/JSchemaPreloadedResolver.cs
+++ b/Src/Newtonsoft.Json.Schema/JSchemaPreloadedResolver.cs
@@ -63,12 +63,7 @@ namespace Newtonsoft.Json.Schema
                 return new MemoryStream(data);
             }
 
-            if (_resolver != null)
-            {
-                return _resolver.GetSchemaResource(context, reference);
-            }
-
-            return null;
+            return _resolver?.GetSchemaResource(context, reference);
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json.Schema/JSchemaValidatingReader.cs
+++ b/Src/Newtonsoft.Json.Schema/JSchemaValidatingReader.cs
@@ -282,9 +282,9 @@ namespace Newtonsoft.Json.Schema
         public override void Close()
         {
             base.Close();
-            if (CloseInput && _reader != null)
+            if (CloseInput)
             {
-                _reader.Close();
+                _reader?.Close();
             }
         }
 

--- a/Src/Newtonsoft.Json.Schema/JSchemaValidatingWriter.cs
+++ b/Src/Newtonsoft.Json.Schema/JSchemaValidatingWriter.cs
@@ -174,9 +174,9 @@ namespace Newtonsoft.Json.Schema
         public override void Close()
         {
             base.Close();
-            if (CloseOutput && _writer != null)
+            if (CloseOutput)
             {
-                _writer.Close();
+                _writer?.Close();
             }
         }
 


### PR DESCRIPTION
Primarily where it means one fewer field-access or simplifies event delegate invocation, though one or two cases have just the lesser advantage of allowing an IL stack `dup` rather than local access.

(Cases that involve introducing a nullable, e.g. where `obj != null ? obj.Value : 0` can be turned into `(obj?.Value) ?? 0` are less clearly wins, and so not done).