### PR TITLE
Fix for deserializing local refs within item schemas

### DIFF
--- a/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue81Tests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue81Tests.cs
@@ -24,11 +24,10 @@ using NUnit.Framework;
 namespace Newtonsoft.Json.Schema.Tests.Issues
 {
     [TestFixture]
-    public class Issue99Tests : TestFixtureBase
+    public class Issue81Tests : TestFixtureBase
     {
         private string originalSchemaJson = @"{
   ""$schema"": ""http://json-schema.org/draft-04/schema#"",
-  ""id"": ""LocalSchema"",
   ""type"": ""object"",
   ""properties"": {
     ""arrayProp"": {
@@ -55,7 +54,6 @@ namespace Newtonsoft.Json.Schema.Tests.Issues
 
         private string remoteReferenceJson = @"{
   ""$schema"": ""http://json-schema.org/draft-04/schema#"",
-  ""id"": ""RemoteSchema"",
   ""definitions"": {
     ""aProperty"": {
       ""type"": ""string""
@@ -65,7 +63,6 @@ namespace Newtonsoft.Json.Schema.Tests.Issues
 
         private string dereferencedSchemaJson = @"{
   ""$schema"": ""http://json-schema.org/draft-04/schema#"",
-  ""id"": ""LocalSchema"",
   ""type"": ""object"",
   ""properties"": {
     ""arrayProp"": {
@@ -83,7 +80,7 @@ namespace Newtonsoft.Json.Schema.Tests.Issues
       ""type"": ""object"",
       ""properties"": {
         ""referencingProp"": {
-          ""$ref"": ""LocalSchema#/properties/arrayProp/items/properties/referencedProp""
+          ""$ref"": ""#/properties/arrayProp/items/properties/referencedProp""
         }
       }
     }
@@ -104,7 +101,7 @@ namespace Newtonsoft.Json.Schema.Tests.Issues
 
             JSchema schema2 = JSchema.Parse(json);
 
-            Assert.AreEqual(schema, schema2);
+            Assert.AreEqual(schema.ToString(), schema2.ToString());
         }
     }
 }

--- a/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue99Tests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue99Tests.cs
@@ -1,0 +1,111 @@
+﻿#region License
+// Copyright (c) Newtonsoft. All Rights Reserved.
+// License: https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md
+#endregion
+
+#if !(NET20 || NET35 || PORTABLE)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema.Generation;
+using Newtonsoft.Json.Schema.Infrastructure;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Schema.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Schema.Tests.Issues
+{
+    [TestFixture]
+    public class Issue99Tests : TestFixtureBase
+    {
+        private string originalSchemaJson = @"{
+  ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+  ""id"": ""LocalSchema"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""arrayProp"": {
+      ""type"": ""array"",
+      ""items"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""referencedProp"": {
+            ""$ref"": ""http://localhost/remoteReference.json#/definitions/aProperty""
+          }
+        }
+      }
+    },
+    ""otherProp"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""referencingProp"": {
+          ""$ref"": ""http://localhost/remoteReference.json#/definitions/aProperty""
+        }
+      }
+    }
+  }
+}";
+
+        private string remoteReferenceJson = @"{
+  ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+  ""id"": ""RemoteSchema"",
+  ""definitions"": {
+    ""aProperty"": {
+      ""type"": ""string""
+    }
+  }
+}";
+
+        private string dereferencedSchemaJson = @"{
+  ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+  ""id"": ""LocalSchema"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""arrayProp"": {
+      ""type"": ""array"",
+      ""items"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""referencedProp"": {
+            ""type"": ""string""
+          }
+        }
+      }
+    },
+    ""otherProp"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""referencingProp"": {
+          ""$ref"": ""LocalSchema#/properties/arrayProp/items/properties/referencedProp""
+        }
+      }
+    }
+  }
+}";
+
+        [Test]
+        public void Test()
+        {
+            JSchemaPreloadedResolver resolver = new JSchemaPreloadedResolver();
+            Stream remoteReferenceStream = new MemoryStream(Encoding.UTF8.GetBytes(remoteReferenceJson));
+            resolver.Add(new Uri("http://localhost/remoteReference.json"), remoteReferenceStream);
+
+            JSchema schema = JSchema.Parse(originalSchemaJson, resolver);
+            string json = schema.ToString();
+
+            StringAssert.AreEqual(dereferencedSchemaJson, json);
+
+            JSchema schema2 = JSchema.Parse(json);
+
+            Assert.AreEqual(schema, schema2);
+        }
+    }
+}
+#endif

--- a/Src/Newtonsoft.Json.Schema.Tests/Newtonsoft.Json.Schema.Tests.csproj
+++ b/Src/Newtonsoft.Json.Schema.Tests/Newtonsoft.Json.Schema.Tests.csproj
@@ -97,7 +97,7 @@
     <Compile Include="Issues\Issue32Tests.cs" />
     <Compile Include="Issues\Issue28Tests.cs" />
     <Compile Include="Issues\Issue03Tests.cs" />
-    <Compile Include="Issues\Issue99Tests.cs" />
+    <Compile Include="Issues\Issue81Tests.cs" />
     <Compile Include="JSchemaTests.cs" />
     <Compile Include="JSchemaValidatingWriterTests.cs" />
     <Compile Include="JSchemaSpecTests.cs" />

--- a/Src/Newtonsoft.Json.Schema.Tests/Newtonsoft.Json.Schema.Tests.csproj
+++ b/Src/Newtonsoft.Json.Schema.Tests/Newtonsoft.Json.Schema.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Issues\Issue32Tests.cs" />
     <Compile Include="Issues\Issue28Tests.cs" />
     <Compile Include="Issues\Issue03Tests.cs" />
+    <Compile Include="Issues\Issue99Tests.cs" />
     <Compile Include="JSchemaTests.cs" />
     <Compile Include="JSchemaValidatingWriterTests.cs" />
     <Compile Include="JSchemaSpecTests.cs" />

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/Discovery/SchemaDiscovery.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/Discovery/SchemaDiscovery.cs
@@ -73,6 +73,17 @@ namespace Newtonsoft.Json.Schema.Infrastructure.Discovery
                                 current = l[index];
                             }
                         }
+                        else if (!schema.ItemsPositionValidation)
+                        {
+                            if (l.Count > 0)
+                            {
+                                current = GetCurrentFromSchema(l[0], unescapedPart);
+                            }
+                            else
+                            {
+                                current = null;
+                            }
+                        }
                         else
                         {
                             current = null;

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/Discovery/SchemaDiscovery.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/Discovery/SchemaDiscovery.cs
@@ -60,6 +60,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure.Discovery
                     else if (current is IList<JSchema>)
                     {
                         IList<JSchema> l = (IList<JSchema>) current;
+                        JSchema parent = schemaReader._schemaStack.LastOrDefault();
 
                         int index;
                         if (int.TryParse(unescapedPart, NumberStyles.None, CultureInfo.InvariantCulture, out index))
@@ -73,7 +74,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure.Discovery
                                 current = l[index];
                             }
                         }
-                        else if (!schema.ItemsPositionValidation)
+                        else if (parent != null && !parent.ItemsPositionValidation)
                         {
                             if (l.Count > 0)
                             {


### PR DESCRIPTION
Hi there,

After the most recent update, I've been running into issues deserializing schemas of a certain shape. It looks like it's likely related to https://github.com/JamesNK/Newtonsoft.Json.Schema/issues/78, but I haven't been able to figure out exactly what the fix is yet.

I've added a failing unit test showing the error that I'm experiencing. Any advice would be appreciated, thanks!