### PR TITLE
Fixing issue 105 date-time format validation problem

### DIFF
--- a/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue0105Tests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue0105Tests.cs
@@ -1,0 +1,74 @@
+﻿#region License
+// Copyright (c) Newtonsoft. All Rights Reserved.
+// License: https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md
+#endregion
+
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Schema.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Schema.Tests.Issues
+{
+    [TestFixture]
+    public class Issue0105Test : TestFixtureBase
+    {
+        [TestCase("1977-02-01T00:00:00Z")]
+        [TestCase("1977-02-01T00:00:00.0Z")]
+        [TestCase("1977-02-01T00:00:00.00Z")]
+        [TestCase("1977-02-01T00:00:00.000Z")]
+        [TestCase("1977-02-01T00:00:00.0000Z")]
+        [TestCase("1977-02-01T00:00:00.00000Z")]
+        [TestCase("1977-02-01T00:00:00+01:00")]
+        [TestCase("1977-02-01T00:00:00.0+01:00")]
+        [TestCase("1977-02-01T00:00:00.00+01:00")]
+        [TestCase("1977-02-01T00:00:00.000+01:00")]
+        [TestCase("1977-02-01T00:00:00.0000+01:00")]
+        [TestCase("1977-02-01T00:00:00.00000+01:00")]
+        public void DateTimeValidPatterns(string validDateTimePattern)
+        {
+            JSchema schema = JSchema.Parse(SchemaJson);
+
+            var o = new JObject
+            {
+                ["someDate"] = validDateTimePattern
+            };
+
+            Assert.That(o.IsValid(schema), Is.True, "Should allow valid date-time pattern");
+        }
+
+        [TestCase("1977-02-01T00:00:00")]
+        [TestCase("1977-02-01T00:00:00.000")]
+        [TestCase("1977-02-01T00:00:00+01")]
+        [TestCase("1977-02-01T00:00:00.000+01")]
+        [TestCase("1977-02-01T00:00:00A")]
+        public void DateTimeInvalidPatterns(string invalidDateTimePattern)
+        {
+            JSchema schema = JSchema.Parse(SchemaJson);
+
+            var o = new JObject
+            {
+                ["someDate"] = invalidDateTimePattern
+            };
+            
+            Assert.That(o.IsValid(schema), Is.False, "Should not allow invalid date-time patterns");
+        }
+        
+        private const string SchemaJson = @"{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""additionalProperties"": false,
+    ""properties"": {
+        ""someDate"": {
+			""type"": ""string"",
+			""description"": ""Some date"",
+			""format"": ""date-time""
+		}
+    }
+}";
+    }
+}

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/Validation/PrimativeScope.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/Validation/PrimativeScope.cs
@@ -300,7 +300,8 @@ namespace Newtonsoft.Json.Schema.Infrastructure.Validation
                 }
                 case Constants.Formats.DateTime:
                 {
-                    return DateTime.TryParseExact(value, @"yyyy-MM-dd\THH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime temp);
+                    return DateTime.TryParseExact(value, @"yyyy-MM-dd\THH:mm:ss.FFFFFFFZ", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime temp1) ||
+                        DateTime.TryParseExact(value, @"yyyy-MM-dd\THH:mm:ss.FFFFFFFzzz", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime temp2);
                 }
                 case Constants.Formats.UtcMilliseconds:
                 {


### PR DESCRIPTION
Issue which allowed timezone offset to be omitted which is not valid under RFC 3339.

'K' in the format string used will match no timezone.