### PR TITLE
Use validators also in referenced schemas

### DIFF
--- a/Src/Newtonsoft.Json.Schema/Infrastructure/JSchemaReader.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/JSchemaReader.cs
@@ -991,7 +991,8 @@ namespace Newtonsoft.Json.Schema.Infrastructure
             {
                 BaseUri = schemaReference.BaseUri,
                 Resolver = _resolver,
-                ValidateVersion = _validateSchema
+                ValidateVersion = _validateSchema,
+                Validators = _validators
             };
             settings.SetValidationEventHandler(_validationEventHandler);
             JSchemaReader schemaReader = new JSchemaReader(settings);


### PR DESCRIPTION
I’ve created this pull request for the case when a schema uses referenced schemas and the referenced schema has fields that need custom validation.
I saw that when the referenced schema is resolved, the validators used to parse the root schema are not passed to the ReaderSettings used to parse the referenced schemas.
For the test case that I’ve created, if we run it without the change in the JSchemaReader, we will get 3 errors: one for custom validation “string is not Json” from the root schema and two for the standard string validations (one from root and one from referenced schema). The custom validation error from the referenced schema is missing.