### PR TITLE
Fix required property list not properly cached in ValidationError

### DIFF
--- a/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue0176Tests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue0176Tests.cs
@@ -1,0 +1,69 @@
+﻿#region License
+// Copyright (c) Newtonsoft. All Rights Reserved.
+// License: https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Schema.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Schema.Tests.Issues
+{
+    [TestFixture]
+    public class Issue0176Tests : TestFixtureBase
+    {
+        [Test]
+        public void Test()
+        {
+            // Arrange
+            JSchema schema = JSchema.Parse(SchemaJson);
+            JObject payload = JObject.Parse(Json);
+
+            // Act
+            bool result = payload.IsValid(schema, out IList<ValidationError> errors);
+
+            // Assert
+            Assert.AreEqual(new List<string> { "line1", "line2" }, errors[0].Value);
+        }
+
+        private const string SchemaJson = @"{
+            'type': 'object',
+            'properties': {
+                    'address': {
+                    'type': 'object',
+                    'properties': {
+                        'line1': {'type':'string'},
+                        'line2': {'type':'string'}
+                    },
+                    'required': [ 'line1', 'line2' ]
+                },
+                'address2': {
+                    'type': 'object',
+                    'properties': {
+                        'line1': {'type':'string'},
+                        'line2': {'type':'string'}
+                    },
+                    'required': [ 'line1', 'line2' ]
+                }
+            },
+            'required': [ 'address', 'address2' ]
+        }";
+
+        private const string Json = @"{
+            'address': {},
+            'address2': {
+                'line1': 'Bar',
+                'line2': 'Boo'
+            }
+        }";
+    }
+}

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/Validation/ObjectScope.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/Validation/ObjectScope.cs
@@ -90,7 +90,9 @@ namespace Newtonsoft.Json.Schema.Infrastructure.Validation
 
                         if (!Schema._required.IsNullOrEmpty() && _requiredProperties.Count > 0)
                         {
-                            RaiseError($"Required properties are missing from object: {StringHelpers.Join(", ", _requiredProperties)}.", ErrorType.Required, Schema, _requiredProperties, null);
+                            //capture required properties at current depth as we may clear _requiredProperties later on
+                            List<string> capturedRequiredProperties = _requiredProperties.ToList();
+                            RaiseError($"Required properties are missing from object: {StringHelpers.Join(", ", capturedRequiredProperties)}.", ErrorType.Required, Schema, capturedRequiredProperties, null);
                         }
 
                         if (Schema.MaximumProperties != null && _propertyCount > Schema.MaximumProperties)


### PR DESCRIPTION
Fixes #176 

I am not sure whether other keywords are impacted by the same type of issue, neither if it can happen with other class derived from `Scope`