### PR TITLE
Add support for NativeAOT

### DIFF
--- a/Src/Newtonsoft.Json.Schema.Tests/Infrastructure/EnumHelpersTests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/Infrastructure/EnumHelpersTests.cs
@@ -21,7 +21,7 @@ namespace Newtonsoft.Json.Schema.Tests.Infrastructure
         [Test]
         public void GetAllEnums()
         {
-            List<JSchemaType> allEnums = EnumHelpers.GetAllEnums<JSchemaType>();
+            List<JSchemaType> allEnums = EnumHelpers.GetAllJSchemaTypeEnums();
 
             CollectionAssert.Contains(allEnums, JSchemaType.None);
             CollectionAssert.Contains(allEnums, JSchemaType.Array);

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/EnumHelpers.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/EnumHelpers.cs
@@ -20,6 +20,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure
             {
                 JSchemaType.None,
                 JSchemaType.String,
+                JSchemaType.Number,
                 JSchemaType.Integer,
                 JSchemaType.Boolean,
                 JSchemaType.Object,

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/EnumHelpers.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/EnumHelpers.cs
@@ -11,11 +11,22 @@ namespace Newtonsoft.Json.Schema.Infrastructure
 {
     internal static class EnumHelpers
     {
-        public static List<T> GetAllEnums<T>() where T : struct
+        public static List<JSchemaType> GetAllJSchemaTypeEnums()
         {
-            List<T> result = new List<T>();
+            List<JSchemaType> result = new List<JSchemaType>();
 
-            int[] values = Enum.GetValues(typeof(T)).Cast<int>().ToArray();
+            // These values should be kept in sync with Src/Newtonsoft.Json.Schema/JSchemaType.cs
+            JSchemaType[] allValues = new[]
+            {
+                JSchemaType.None,
+                JSchemaType.String,
+                JSchemaType.Integer,
+                JSchemaType.Boolean,
+                JSchemaType.Object,
+                JSchemaType.Array,
+                JSchemaType.Null,
+            };
+            int[] values = allValues.Cast<int>().ToArray();
             int[] valuesInverted = values.Select(v => ~v).ToArray();
             int max = 0;
             for (int i = 0; i < values.Length; i++)
@@ -31,7 +42,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure
                     unaccountedBits &= valuesInverted[j];
                     if (unaccountedBits == 0)
                     {
-                        result.Add((T)(object)i);
+                        result.Add((JSchemaType)i);
                         break;
                     }
                 }

--- a/Src/Newtonsoft.Json.Schema/Infrastructure/JSchemaTypeHelpers.cs
+++ b/Src/Newtonsoft.Json.Schema/Infrastructure/JSchemaTypeHelpers.cs
@@ -18,7 +18,7 @@ namespace Newtonsoft.Json.Schema.Infrastructure
 
         static JSchemaTypeHelpers()
         {
-            List<JSchemaType> allValues = EnumHelpers.GetAllEnums<JSchemaType>();
+            List<JSchemaType> allValues = EnumHelpers.GetAllJSchemaTypeEnums();
             CachedSchemaTypeNames = new Dictionary<JSchemaType, string>(allValues.Count);
 
             foreach (JSchemaType type in allValues)


### PR DESCRIPTION
See #251
Save precomputed values into local variables to avoid adding one more target, like was done in #273
Change name of the function, to reflect new non-generic nature of the code.