### PR TITLE
Added (On)SchemaGenerated to JSchemaGenerator

### DIFF
--- a/Src/Newtonsoft.Json.Schema/Generation/JSchemaGenerator.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/JSchemaGenerator.cs
@@ -98,6 +98,12 @@ namespace Newtonsoft.Json.Schema.Generation
         }
 
         /// <summary>
+        /// Is called each time a schema is generated.
+        /// Allows the user to manipulate the schema. 
+        /// </summary>
+        public Action<Type, JSchema>? SchemaGenerated;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JSchemaGenerator"/> class.
         /// </summary>
         public JSchemaGenerator()
@@ -134,6 +140,15 @@ namespace Newtonsoft.Json.Schema.Generation
 
             JSchemaGeneratorInternal generator = new JSchemaGeneratorInternal(this);
             return generator.Generate(type, required);
+        }
+
+        /// <summary>
+        /// Is called each time a schema is generated.
+        /// Allows the user to manipulate the schema. 
+        /// </summary>
+        internal protected virtual void OnSchemaGenerated(Type type, JSchema schema)
+        {
+            this.SchemaGenerated?.Invoke(type, schema);
         }
     }
 }

--- a/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/JSchemaGeneratorInternal.cs
@@ -309,6 +309,8 @@ namespace Newtonsoft.Json.Schema.Generation
                 PopulateSchema(schema, contract, memberProperty, resolvedRequired);
             }
 
+            _generator.OnSchemaGenerated(type, schema);
+
             return schema;
         }
 


### PR DESCRIPTION
The proposed addition is intended to allow users to easily manipulate the JSchema after is gets generated. This is especially helpful with inline schemas that are not reachable otherwise.