### PR TITLE
 StringEnumGenerationProvider support custom NamingStrategy

### DIFF
--- a/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue0111Tests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/Issues/Issue0111Tests.cs
@@ -32,12 +32,14 @@ namespace Newtonsoft.Json.Schema.Tests.Issues
         public void Test()
         {
             JSchemaGenerator stringEnumGenerator = new JSchemaGenerator();
-            
+
+#pragma warning disable CS0618 // Type or member is obsolete
             stringEnumGenerator.GenerationProviders.Add(new StringEnumGenerationProvider
             {
                 CamelCaseText = true
             });
-            
+#pragma warning restore CS0618 // Type or member is obsolete
+
             JSchema stringEnumSchema = stringEnumGenerator.Generate(typeof(BuildingReport));
 
             string json = @"{

--- a/Src/Newtonsoft.Json.Schema.Tests/JSchemaGeneratorTests.cs
+++ b/Src/Newtonsoft.Json.Schema.Tests/JSchemaGeneratorTests.cs
@@ -1691,9 +1691,9 @@ namespace Newtonsoft.Json.Schema.Tests
         [JsonConverter(typeof(StringEnumConverter))]
         public enum SortTypeFlagAsString
         {
-            No = 0,
-            Asc = 1,
-            Desc = -1
+            NoSort = 0,
+            AscSort = 1,
+            DescSort = -1
         }
 
         public class Y
@@ -1701,14 +1701,45 @@ namespace Newtonsoft.Json.Schema.Tests
             public SortTypeFlagAsString y;
         }
 
-#if !DNXCORE50
         [Test]
-        public void GenerateSchemaWithStringEnum()
+        public void GenerateSchemaWithStringEnum_CamelCase()
+        {
+            JSchemaGenerator generator = new JSchemaGenerator();
+#pragma warning disable CS0618 // Type or member is obsolete
+            generator.GenerationProviders.Add(new StringEnumGenerationProvider
+            {
+                CamelCaseText = true
+            });
+#pragma warning restore CS0618 // Type or member is obsolete
+            JSchema schema = generator.Generate(typeof(Y));
+
+            string json = schema.ToString();
+
+            StringAssert.AreEqual(@"{
+  ""type"": ""object"",
+  ""properties"": {
+    ""y"": {
+      ""type"": ""string"",
+      ""enum"": [
+        ""noSort"",
+        ""ascSort"",
+        ""descSort""
+      ]
+    }
+  },
+  ""required"": [
+    ""y""
+  ]
+}", json);
+        }
+
+        [Test]
+        public void GenerateSchemaWithStringEnum_NamingStrategy()
         {
             JSchemaGenerator generator = new JSchemaGenerator();
             generator.GenerationProviders.Add(new StringEnumGenerationProvider
             {
-                CamelCaseText = true
+                NamingStrategy = new SnakeCaseNamingStrategy()
             });
             JSchema schema = generator.Generate(typeof(Y));
 
@@ -1720,9 +1751,9 @@ namespace Newtonsoft.Json.Schema.Tests
     ""y"": {
       ""type"": ""string"",
       ""enum"": [
-        ""no"",
-        ""asc"",
-        ""desc""
+        ""no_sort"",
+        ""asc_sort"",
+        ""desc_sort""
       ]
     }
   },
@@ -1731,7 +1762,6 @@ namespace Newtonsoft.Json.Schema.Tests
   ]
 }", json);
         }
-#endif
 
         [Test]
         public void DefinitionsOrder()

--- a/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
@@ -22,9 +22,10 @@ namespace Newtonsoft.Json.Schema.Generation
 
         /// <summary>
         /// Gets or sets a value indicating whether the written enum text should be camel case.
+        /// <br/>
+        /// This property is obsolete and has been replaced by the NamingStrategy property.
         /// </summary>
         /// <value><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</value>
-        [Obsolete("This property is obsolete and has been replaced by the NamingStrategy property.")]
         public bool CamelCaseText
         {
             get => _camelCaseText;

--- a/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
@@ -22,10 +22,9 @@ namespace Newtonsoft.Json.Schema.Generation
 
         /// <summary>
         /// Gets or sets a value indicating whether the written enum text should be camel case.
-        /// <br/>
-        /// This property is obsolete and has been replaced by the NamingStrategy property.
         /// </summary>
         /// <value><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</value>
+        [Obsolete("This property is obsolete and has been replaced by the NamingStrategy property. Set the new property to an instance of CamelCaseNamingStrategy to perverse the current behavior.")]
         public bool CamelCaseText
         {
             get => _camelCaseText;

--- a/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
@@ -15,7 +15,7 @@ namespace Newtonsoft.Json.Schema.Generation
     /// </summary>
     public class StringEnumGenerationProvider : JSchemaGenerationProvider
     {
-        private static readonly NamingStrategy _camelCaseNamingStrategy = new CamelCaseNamingStrategy();
+        private static readonly CamelCaseNamingStrategy _camelCaseNamingStrategy = new CamelCaseNamingStrategy();
 
         private bool _camelCaseText;
         private NamingStrategy? _nameStrategy;

--- a/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
+++ b/Src/Newtonsoft.Json.Schema/Generation/StringEnumGenerationProvider.cs
@@ -15,13 +15,54 @@ namespace Newtonsoft.Json.Schema.Generation
     /// </summary>
     public class StringEnumGenerationProvider : JSchemaGenerationProvider
     {
-        private static readonly CamelCaseNamingStrategy _camelCaseNamingStrategy = new CamelCaseNamingStrategy();
+        private static readonly NamingStrategy _camelCaseNamingStrategy = new CamelCaseNamingStrategy();
+
+        private bool _camelCaseText;
+        private NamingStrategy? _nameStrategy;
 
         /// <summary>
         /// Gets or sets a value indicating whether the written enum text should be camel case.
         /// </summary>
         /// <value><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</value>
-        public bool CamelCaseText { get; set; }
+        [Obsolete("This property is obsolete and has been replaced by the NamingStrategy property.")]
+        public bool CamelCaseText
+        {
+            get => _camelCaseText;
+            set
+            {
+                _camelCaseText = value;
+                // we use this to ensure compatibility with the old property.
+                NamingStrategy = value ? _camelCaseNamingStrategy : null;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the naming strategy used to resolve enum values.
+        /// </summary>
+        public NamingStrategy? NamingStrategy
+        {
+            get => _nameStrategy;
+            set
+            {
+                _nameStrategy = value;
+                // we use this to ensure compatibility with the old property.
+                _camelCaseText = (typeof(CamelCaseNamingStrategy) == value?.GetType());
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringEnumGenerationProvider"/> class.
+        /// </summary>
+        public StringEnumGenerationProvider() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringEnumGenerationProvider"/> class 
+        /// with a specified naming strategy.
+        /// </summary>
+        public StringEnumGenerationProvider(NamingStrategy namingStrategy)
+        {
+            NamingStrategy = namingStrategy;
+        }
 
         /// <summary>
         /// Gets a <see cref="JSchema"/> for a <see cref="Type"/>.
@@ -49,12 +90,12 @@ namespace Newtonsoft.Json.Schema.Generation
             object? defaultValue = context.MemberProperty?.DefaultValue;
             if (defaultValue != null)
             {
-                EnumUtils.TryToString(t, defaultValue, GetResolveNamingStrategy(), out string? finalName);
+                EnumUtils.TryToString(t, defaultValue, NamingStrategy, out string? finalName);
 
                 schema.Default = JToken.FromObject(finalName ?? defaultValue.ToString());
             }
 
-            EnumInfo enumValues = EnumUtils.GetEnumValuesAndNames(t, GetResolveNamingStrategy());
+            EnumInfo enumValues = EnumUtils.GetEnumValuesAndNames(t, NamingStrategy);
 
             for (int i = 0; i < enumValues.Values.Length; i++)
             {
@@ -64,11 +105,6 @@ namespace Newtonsoft.Json.Schema.Generation
             }
 
             return schema;
-        }
-
-        private NamingStrategy? GetResolveNamingStrategy()
-        {
-            return CamelCaseText ? _camelCaseNamingStrategy : null;
         }
 
         /// <summary>


### PR DESCRIPTION
This makes StringEnumGenerationProvider support all naming strategies, not only camel-case.
To maintain compatibility, the original CamelCaseText property is retained ~and marked as obsolete~. It should be removed at an opportune time in the future.